### PR TITLE
Add option for displaying seed name

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -19,8 +19,9 @@ node shuffle multi -e "build/patcher/extraction-aliased.json" -o "build/current-
   --rewardShuffler.on=true \
   --roomShuffler.on=true \
   --stageShuffler.on=true \
-  --stageShuffler.labels=true \
-  --solver.on=true
+  --solver.on=true \
+  --hinter.seedName=true \
+  --hinter.stageLinks=true
 
 node lib/BIN-Patcher/sotn alter -s "build/patcher/extraction-masked-aliased.json" -t "build/current-patch.json"
 node lib/BIN-Patcher/sotn patch -p "build/current-patch.json" -c "build/current-seed.json"

--- a/patch.sh
+++ b/patch.sh
@@ -21,6 +21,7 @@ node shuffle multi -e "build/patcher/extraction-aliased.json" -o "build/current-
   --stageShuffler.on=true \
   --solver.on=true \
   --hinter.seedName=true \
+  --hinter.settings=true \
   --hinter.stageLinks=true
 
 node lib/BIN-Patcher/sotn alter -s "build/patcher/extraction-masked-aliased.json" -t "build/current-patch.json"

--- a/shuffle.js
+++ b/shuffle.js
@@ -10,6 +10,7 @@ import {
 import {
     arrangeStages,
     getStageAndRoomFromLink,
+    hashedObject,
 } from './src/common.js'
 
 import {
@@ -939,6 +940,15 @@ const argv = yargs(process.argv.slice(2))
                 describe: 'Seed to provide for randomization',
                 type: 'string',
             })
+        // Hinter options
+            .option('hinter.seedName', {
+                describe: 'Whether or not to display the seed value on the file select screen',
+                type: 'boolean',
+            })
+            .option('hinter.stageLinks', {
+                describe: 'Whether or not to add a label identifying each pair of loading rooms on the castle map; will only apply to loading room pairs that do not occupy the same map position already',
+                type: 'boolean',
+            })
         // Music shuffler options
             .option('musicShuffler.on', {
                 describe: 'Whether or not to enable shuffling of in-game music; if disabled, all other options in this category are ignored',
@@ -1000,10 +1010,6 @@ const argv = yargs(process.argv.slice(2))
                 describe: 'If supplied, this seed is always used for supplying randomness to the stage shuffler',
                 type: 'string',
             })
-            .option('stageShuffler.labels', {
-                describe: 'Whether or not to add a label identifying each pair of loading rooms on the castle map',
-                type: 'boolean',
-            })
         // The following options must be declared
             .demandOption(['extraction', 'out'])
         },
@@ -1034,6 +1040,9 @@ const argv = yargs(process.argv.slice(2))
                 seedName = getSeedName(seed)
             }
             shuffleData.debugInfo.seedName = seedName
+            if (argv.hinter) {
+                shuffleData.settings.hinter = argv.hinter
+            }
             if (argv.musicShuffler?.on) {
                 shuffleData.settings.musicShuffler = argv.musicShuffler
             }
@@ -1247,7 +1256,7 @@ const argv = yargs(process.argv.slice(2))
             }
             // Add labels to map
             let mapPixels = MAP_PIXELS
-            if (argv.stageShuffler?.labels && (
+            if (argv.hinter?.stageLinks && (
                 argv.stageShuffler?.on || argv.roomShuffler?.on
             )) {
                 mapPixels = getMapPixels(stageConnections.links, roomArrangements.rooms)
@@ -1307,6 +1316,20 @@ const argv = yargs(process.argv.slice(2))
                 },
             }
             changesToAdd.push(mapChanges)
+            // Add hints
+            if (argv.hinter?.seedName) {
+                const hintChanges = {
+                    changeType: 'merge',
+                    merge: {
+                        'messages.richterModeInstructions1.data=': seedName,
+                        'messages.richterModeInstructions2.data=': hashedObject(shuffleData.settings, ['seedName']),
+                    },
+                }
+                changesToAdd.push(hintChanges)
+            }
+            console.log('hashedObject(...):', hashedObject(shuffleData.settings, ['seedName']))
+            console.log('shuffleData.settings:', shuffleData.settings)
+            // Transfer accumulated changes
             for (let index = 0; index < changesToAdd.length; index++) {
                 shuffleData.changes.push(changesToAdd.at(index))
             }

--- a/shuffle.js
+++ b/shuffle.js
@@ -945,6 +945,12 @@ const argv = yargs(process.argv.slice(2))
                 describe: 'Whether or not to display the seed value on the file select screen',
                 type: 'boolean',
             })
+            .option('hinter.settings', {
+                describe: 'Whether or not to display a hash value of the settings used on the file select screen',
+                type: 'boolean',
+                // The hash value can be used to demonstrate that two separate PPFs were very likely generated with the same settings.
+                // It is only meant to help in catching accidental settings changes, and may not help in catching well-crafted, malicious ones.
+            })
             .option('hinter.stageLinks', {
                 describe: 'Whether or not to add a label identifying each pair of loading rooms on the castle map; will only apply to loading room pairs that do not occupy the same map position already',
                 type: 'boolean',
@@ -1316,19 +1322,21 @@ const argv = yargs(process.argv.slice(2))
                 },
             }
             changesToAdd.push(mapChanges)
-            // Add hints
-            if (argv.hinter?.seedName) {
+            // Add hints to the file select menu
+            if (argv.hinter?.seedName || argv.hinter?.settings) {
+                const hintMessages = [
+                    (argv.hinter?.seedName) ? seedName : '',
+                    (argv.hinter?.settings) ? hashedObject(shuffleData.settings, ['seedName']) : '',
+                ]
                 const hintChanges = {
                     changeType: 'merge',
                     merge: {
-                        'messages.richterModeInstructions1.data=': seedName,
-                        'messages.richterModeInstructions2.data=': hashedObject(shuffleData.settings, ['seedName']),
+                        'messages.richterModeInstructions1.data=': hintMessages.at(0),
+                        'messages.richterModeInstructions2.data=': hintMessages.at(1),
                     },
                 }
                 changesToAdd.push(hintChanges)
             }
-            console.log('hashedObject(...):', hashedObject(shuffleData.settings, ['seedName']))
-            console.log('shuffleData.settings:', shuffleData.settings)
             // Transfer accumulated changes
             for (let index = 0; index < changesToAdd.length; index++) {
                 shuffleData.changes.push(changesToAdd.at(index))

--- a/src/analyze-logic.js
+++ b/src/analyze-logic.js
@@ -1,4 +1,5 @@
 import { inspect } from 'node:util'
+
 import {
     LOCATIONS,
     NODES,
@@ -7,6 +8,10 @@ import {
     ROOMS_INFO,
     TELEPORTERS,
 } from './constants.js'
+
+import {
+    hashedState,
+} from './common.js'
 
 function isValidRequirement(state, requirement) {
     const result = Object.entries(requirement)
@@ -548,60 +553,6 @@ function getLogic(settings, enableElsewhere=false) {
                 })
             })
         })
-    }
-    return result
-}
-
-function hashedState(state, simple=false) {
-    // Example: abandonedMine.bend.main.b8e6fb7c
-    const elements = []
-    elements.push(state.stage ?? 'NONE')
-    elements.push(state.room ?? 'NONE')
-    elements.push(state.section ?? 'NONE')
-    if (!simple) {
-        elements.push(hashedObject(state, ['stage', 'room', 'section', 'time', 'positionX', 'positionY']))
-    }
-    const result = elements.join('.')
-    return result
-}
-
-function hashedObject(object, ignoredProperties) {
-    const elements = []
-    Object.keys(object)
-    .filter((key) => {
-        return !(ignoredProperties.includes(key))
-    })
-    .sort()
-    .forEach((key) => {
-        switch (typeof object[key]) {
-            case 'boolean':
-            case 'number':
-            case 'string':
-                elements.push([key, object[key]].join('='))
-                break
-            case 'object':
-                elements.push([key, hashedObject(object[key])].join('='))
-                break
-            default:
-                console.log('Unhandled key-value pair: ' + JSON.stringify(key) + ', ' + JSON.stringify(object[key]))
-                break
-        }
-    })
-    const result = hashedText(elements.join('|'))
-    return result
-}
-
-// Javascript implementation of DJBX33A as defined at https://stackoverflow.com/questions/10696223/reason-for-the-number-5381-in-the-djb-hash-function
-function hashedText(text) {
-    const MOD = Math.pow(2, 32)
-    let value = 5381
-    for (let i = 0; i < text.length; i++) {
-        value = ((33 * value) + text.charCodeAt(i)) % MOD
-    }
-    let result = ''
-    for (let i = 0; i < 8; i++) {
-        result += '0123456789abcdef'.at(value % 16)
-        value = Math.floor(value / 16)
     }
     return result
 }

--- a/src/common.js
+++ b/src/common.js
@@ -80,3 +80,57 @@ export function arrangeStages(seed, startingNodeGroups) {
     }
     return result
 }
+
+export function hashedState(state, simple=false) {
+    // Example: abandonedMine.bend.main.b8e6fb7c
+    const elements = []
+    elements.push(state.stage ?? 'NONE')
+    elements.push(state.room ?? 'NONE')
+    elements.push(state.section ?? 'NONE')
+    if (!simple) {
+        elements.push(hashedObject(state, ['stage', 'room', 'section', 'time', 'positionX', 'positionY']))
+    }
+    const result = elements.join('.')
+    return result
+}
+
+export function hashedObject(object, ignoredProperties=[]) {
+    const elements = []
+    Object.keys(object)
+    .filter((key) => {
+        return !(ignoredProperties.includes(key))
+    })
+    .sort()
+    .forEach((key) => {
+        switch (typeof object[key]) {
+            case 'boolean':
+            case 'number':
+            case 'string':
+                elements.push([key, object[key]].join('='))
+                break
+            case 'object':
+                elements.push([key, hashedObject(object[key])].join('='))
+                break
+            default:
+                console.log('Unhandled key-value pair: ' + JSON.stringify(key) + ', ' + JSON.stringify(object[key]))
+                break
+        }
+    })
+    const result = hashedText(elements.join('|'))
+    return result
+}
+
+// Javascript implementation of DJBX33A as defined at https://stackoverflow.com/questions/10696223/reason-for-the-number-5381-in-the-djb-hash-function
+export function hashedText(text) {
+    const MOD = Math.pow(2, 32)
+    let value = 5381
+    for (let i = 0; i < text.length; i++) {
+        value = ((33 * value) + text.charCodeAt(i)) % MOD
+    }
+    let result = ''
+    for (let i = 0; i < 8; i++) {
+        result += '0123456789abcdef'.at(value % 16)
+        value = Math.floor(value / 16)
+    }
+    return result
+}


### PR DESCRIPTION
The option for adding labels to loading rooms has moved under the hinter option. The message on the file select screen that tells you how to play as Richter (after getting a CLEAR file) can now show the seed name and/or a hash of the settings used to generate the PPF.

A bug where 'relicPowerOfWolf' was not changed to 'locationPowerOfWolf' in one of the patches has also been included.